### PR TITLE
Fix for #53 - Added root path for generic provider

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
                 '"org.mozilla.fennec_andrei.a.lazar"',
                 '"org.mozilla.fennec_aurora"',
                 '"org.mozilla.firefox_beta"',
-                '"org.mozilla.firefox'
+                '"org.mozilla.firefox"'
         ]
 
         def FENNEC_SHARED_USER_IDS = [

--- a/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
@@ -125,7 +125,7 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
         shareIntent.putExtra(
             Intent.EXTRA_STREAM,
             FileProvider.getUriForFile(
-                this, this.applicationContext.packageName + ".provider",
+                this, BuildConfig.APPLICATION_ID + ".provider",
                 File("${getBackupStoragePath(this)}/${item.name}")
             )
         )

--- a/app/src/main/res/xml/provider_paths.xml
+++ b/app/src/main/res/xml/provider_paths.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<paths xmlns:android="http://schemas.android.com/apk/res/android">
-    <external-path name="external_files" path="."/>
+<paths>
+    <root-path
+        name="root"
+        path="." />
+    <external-path
+        name="external"
+        path="." />
+    <external-files-path
+        name="external_files"
+        path="." />
+    <cache-path
+        name="cache"
+        path="." />
+    <external-cache-path
+        name="external_cache"
+        path="." />
+    <files-path
+        name="files"
+        path="." />
 </paths>


### PR DESCRIPTION
Added root path for generic provider in order to provide root path of internal storage.