### PR TITLE
Fix for #42 - Cannot apply backups that contains spaces in name

### DIFF
--- a/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
+++ b/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
@@ -91,7 +91,7 @@ object BackupRepositoryImpl : BackupRepository {
         }
 
         val inputStream: InputStream? = ctx.contentResolver.openInputStream(fileUri)
-        val copy = File("${getBackupStoragePath(ctx)}/$fileName")
+        val copy = File("${getBackupStoragePath(ctx)}/${fileName.replace(" ", "_")}")
         val outputStream: OutputStream = FileOutputStream(copy)
         inputStream?.copyTo(outputStream, DEFAULT_BUFFER_SIZE)
     }

--- a/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
@@ -287,7 +287,7 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
                     return@setPositiveButton
                 }
 
-                presenter.createBackup(input.text.toString())
+                presenter.createBackup(input.text.toString().replace(" ", "_"))
             }
         }
         builder.setNegativeButton(getString(R.string.cancel), null)


### PR DESCRIPTION
Now we are escaping blank spaces by replacing them with underscores