### PR TITLE
Fix for #61 - Blank spaces introduced from edit mode are not escaped

### DIFF
--- a/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
+++ b/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
@@ -8,6 +8,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
 import android.util.Log
+import androidx.core.net.toFile
 import org.mozilla.fpm.BuildConfig
 import org.mozilla.fpm.models.Backup
 import org.mozilla.fpm.utils.CryptUtils
@@ -25,7 +26,6 @@ import java.io.OutputStream
 @SuppressLint("StaticFieldLeak")
 object BackupRepositoryImpl : BackupRepository {
     const val MIME_TYPE = "fpm"
-    private const val KILOBYTE: Long = 1024
     private lateinit var ctx: Context
 
     fun setContext(ctx: Context) {
@@ -91,7 +91,7 @@ object BackupRepositoryImpl : BackupRepository {
         }
 
         val inputStream: InputStream? = ctx.contentResolver.openInputStream(fileUri)
-        val copy = File("${getBackupStoragePath(ctx)}/${fileName.replace(" ", "_")}")
+        val copy = Uri.parse("file://${getBackupStoragePath(ctx)}/$fileName").toFile()
         val outputStream: OutputStream = FileOutputStream(copy)
         inputStream?.copyTo(outputStream, DEFAULT_BUFFER_SIZE)
     }
@@ -144,7 +144,7 @@ object BackupRepositoryImpl : BackupRepository {
                     it.name,
                     Utils.getFormattedDate(it.lastModified()),
                     getFileSignature("${getBackupStoragePath(ctx)}/${it.name}"),
-                    it.length() / KILOBYTE
+                    it.length()
                 )
             }
         }
@@ -165,7 +165,7 @@ object BackupRepositoryImpl : BackupRepository {
                     it.name,
                     Utils.getFormattedDate(it.lastModified()),
                     getFileSignature("${getBackupStoragePath(ctx)}/${it.name}"),
-                    it.length() / KILOBYTE
+                    it.length()
                 )
             )
         }

--- a/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
@@ -172,8 +172,8 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
                     return@setPositiveButton
                 }
 
-                presenter.renameBackup(item, input.text.toString())
-                adapter.update(Backup(input.text.toString(), item.createdAt, item.variant, item.size), position)
+                presenter.renameBackup(item, input.text.toString().replace(" ", "_"))
+                adapter.update(Backup(input.text.toString().replace(" ", "_"), item.createdAt, item.variant, item.size), position)
             }
         }
         builder.setNegativeButton(getString(R.string.cancel), null)

--- a/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
@@ -144,7 +144,7 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
 
     override fun onShareClick(item: Backup) {
         val shareIntent = Intent(Intent.ACTION_SEND)
-        shareIntent.type = "application/zip"
+        shareIntent.type = "*/*"
         shareIntent.putExtra(
             Intent.EXTRA_STREAM,
             FileProvider.getUriForFile(
@@ -172,8 +172,8 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
                     return@setPositiveButton
                 }
 
-                presenter.renameBackup(item, input.text.toString().replace(" ", "_"))
-                adapter.update(Backup(input.text.toString().replace(" ", "_"), item.createdAt, item.variant, item.size), position)
+                presenter.renameBackup(item, input.text.toString())
+                adapter.update(Backup(input.text.toString(), item.createdAt, item.variant, item.size), position)
             }
         }
         builder.setNegativeButton(getString(R.string.cancel), null)
@@ -287,7 +287,7 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
                     return@setPositiveButton
                 }
 
-                presenter.createBackup(input.text.toString().replace(" ", "_"))
+                presenter.createBackup(input.text.toString())
             }
         }
         builder.setNegativeButton(getString(R.string.cancel), null)
@@ -296,7 +296,7 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
 
     fun launchFilePicker() {
         var pickIntent = Intent(Intent.ACTION_GET_CONTENT)
-        pickIntent.type = "application/zip"
+        pickIntent.type = "*/*"
         pickIntent = Intent.createChooser(pickIntent, getString(R.string.choose_backup))
         startActivityForResult(pickIntent, PICK_BACKUP_RESULT_CODE)
     }


### PR DESCRIPTION
In order to safely escape the blank spaces we are replacing them with underscores.