### PR TITLE
For #41 - Use AES 256 for a stronger encryption

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,15 +25,15 @@ android {
                         "\"org.mozilla.firefox.sharedID\"" + "}"
 
         // the secret key size depends on the algorithm used for encrypting / decrypting
-        def secreyKeySizeReq = 8
+        def secretKeySizeReq = 32
         def secretKeyFilename = "secret.key"
         def file = new File(secretKeyFilename)
         assert file.exists() : "\"$secretKeyFilename\" file not found"
         assert file.canRead() : "\"$secretKeyFilename\" file cannot be read"
         def secretKey = file.text.replace("\n", "")
-        assert (secretKey.bytes.length == secreyKeySizeReq) :
+        assert (secretKey.bytes.length == secretKeySizeReq) :
                 "Secret key declared in the \"$secretKeyFilename\" file has ${secretKey.bytes.length} bytes." +
-                        "\nNeed it to have $secreyKeySizeReq bytes.\n"
+                        "\nNeed it to have $secretKeySizeReq bytes.\n"
         buildConfigField "String", "SECRET_KEY", '"' + secretKey + '"'
     }
 

--- a/app/src/main/java/org/mozilla/fpm/utils/CryptUtils.java
+++ b/app/src/main/java/org/mozilla/fpm/utils/CryptUtils.java
@@ -16,16 +16,21 @@ import javax.crypto.spec.SecretKeySpec;
 
 public final class CryptUtils {
     private static final String LOGTAG = "CryptUtils";
+    private static final String SECRET_KEY_ALGORITHM = "AES";
+    private static final String TRANSFORMATION = SECRET_KEY_ALGORITHM + "/CBC/PKCS5Padding";
     private static final String KEY = BuildConfig.SECRET_KEY;
-    private static final byte[] iv = {
+    // 16 byte initialization vector needed for AES encryption
+    private static byte[] iv = {
             (byte) 0xB2, (byte) 0x12, (byte) 0xD5, (byte) 0xB2,
-            (byte) 0x44, (byte) 0x21, (byte) 0xC3, (byte) 0xC3
+            (byte) 0x44, (byte) 0x21, (byte) 0xC3, (byte) 0xC3,
+            (byte) 0xFF, (byte) 0x14, (byte) 0xC0, (byte) 0x11,
+            (byte) 0x4B, (byte) 0x2F, (byte) 0x33, (byte) 0xC9,
     };
 
     public void encrypt(InputStream is, OutputStream os) {
         try {
-            final Cipher ecipher = Cipher.getInstance("DES/CBC/PKCS5Padding");
-            final SecretKeySpec key = new SecretKeySpec(KEY.getBytes(), "DES");
+            final Cipher ecipher = Cipher.getInstance(TRANSFORMATION);
+            final SecretKeySpec key = new SecretKeySpec(KEY.getBytes(), SECRET_KEY_ALGORITHM);
             final AlgorithmParameterSpec paramSpec = new IvParameterSpec(iv);
             ecipher.init(Cipher.ENCRYPT_MODE, key, paramSpec);
 
@@ -50,8 +55,8 @@ public final class CryptUtils {
 
     public void decrypt(InputStream is, OutputStream os) {
         try {
-            final Cipher dcipher = Cipher.getInstance("DES/CBC/PKCS5Padding");
-            final SecretKeySpec key = new SecretKeySpec(KEY.getBytes(), "DES");
+            final Cipher dcipher = Cipher.getInstance(TRANSFORMATION);
+            final SecretKeySpec key = new SecretKeySpec(KEY.getBytes(), SECRET_KEY_ALGORITHM);
             final AlgorithmParameterSpec paramSpec = new IvParameterSpec(iv);
             dcipher.init(Cipher.DECRYPT_MODE, key, paramSpec);
 


### PR DESCRIPTION
AES 256 uses a 32 bytes secret key, asserted at compile time.