### PR TITLE
Fix #71 - Swallow existent file crash if symlink

### DIFF
--- a/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
+++ b/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
@@ -25,6 +25,7 @@ import java.io.OutputStream
 
 @SuppressLint("StaticFieldLeak")
 object BackupRepositoryImpl : BackupRepository {
+    private const val LOGTAG = "BackupRepository"
     const val MIME_TYPE = "fpm"
     private lateinit var ctx: Context
 
@@ -107,7 +108,10 @@ object BackupRepositoryImpl : BackupRepository {
 
         if (deployPath != null) {
             // remove the current state of Firefox
-            File(deployPath).deleteRecursively()
+
+            if (File(deployPath).deleteRecursively().not()) {
+                Log.w(LOGTAG, "Could not clear Fennec's internal storage")
+            }
 
             val sign = getFileSignature("${getBackupStoragePath(ctx)}/$name")
             val backupFile = File("${getBackupStoragePath(ctx)}/$name")


### PR DESCRIPTION
On some devices the data/data/app_package/lib directory is just a symlink while
on other devices that directory contains the actual extracted libs.
The actual files can be overwritten by us.
The symlinked files (and directory) is only readable by us and so when trying
to create a new FileOutputStream for such a file we would get a
FileNotFoundException.
To avoid crashing in such scenarios we'll swallow the exception if and only if
we can confidently know the file exists, just we don't have write access to it.