### PR TITLE
Fix 72 - Automatically add a suffix to backup names to ensure their uniqueness

### DIFF
--- a/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
+++ b/app/src/main/java/org/mozilla/fpm/data/BackupRepositoryImpl.kt
@@ -143,7 +143,7 @@ object BackupRepositoryImpl : BackupRepository {
         File("${getBackupStoragePath(ctx)}/${t.name}").renameTo(File("${getBackupStoragePath(ctx)}/$k"))
     }
 
-    override fun get(k: String): Backup {
+    override fun get(k: String): Backup? {
         File(getBackupStoragePath(ctx)).listFiles()?.forEach {
             if (it.name == k) {
                 return Backup(
@@ -155,7 +155,7 @@ object BackupRepositoryImpl : BackupRepository {
             }
         }
 
-        return Backup("", "", "", 0)
+        return null
     }
 
     override fun getAll(): List<Backup> {

--- a/app/src/main/java/org/mozilla/fpm/data/Repository.kt
+++ b/app/src/main/java/org/mozilla/fpm/data/Repository.kt
@@ -8,6 +8,6 @@ interface Repository<T, K> {
     fun create(k: K)
     fun remove(k: K)
     fun update(t: T, k: K)
-    fun get(k: K): T
+    fun get(k: K): T?
     fun getAll(): List<T>
 }

--- a/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
@@ -221,6 +221,10 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
         refresh_layout.isRefreshing = false
     }
 
+    override fun showBackupCreatedWithDifferentNameMessage(actualBackupName: String) {
+        showMessage(this, getString(R.string.backup_created_with_different_name_message, actualBackupName))
+    }
+
     override fun onBackupApplied() {
         showMessage(this, getString(R.string.backup_applied))
     }

--- a/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/MainActivity.kt
@@ -166,18 +166,17 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
         builder.setTitle(getString(R.string.edit_backup_name))
         val dialogLayout = inflater.inflate(R.layout.alert_input, null)
         val input = dialogLayout.findViewById<EditText>(R.id.input)
-        input.setText(item.name.replace(".$MIME_TYPE", ""))
+        input.setText(item.name.substringBefore(".$MIME_TYPE"))
         builder.setView(dialogLayout)
         builder.setPositiveButton(getString(R.string.ok)) { _, _ ->
+            val updatedBackupName = input.text.toString()
             run {
-                if (input.text.isEmpty()) {
+                if (updatedBackupName.isEmpty()) {
                     showMessage(this@MainActivity, getString(R.string.error_input_null))
                     return@setPositiveButton
                 }
 
-                val newName = input.text.toString().plus(".$MIME_TYPE")
-                presenter.renameBackup(item, newName)
-                adapter.update(Backup(newName, item.createdAt, item.variant, item.size), position)
+                presenter.renameBackup(item, updatedBackupName, position)
             }
         }
         builder.setNegativeButton(getString(R.string.cancel), null)
@@ -223,6 +222,10 @@ class MainActivity : AppCompatActivity(), MainContract.View, BackupsRVAdapter.Me
 
     override fun showBackupCreatedWithDifferentNameMessage(actualBackupName: String) {
         showMessage(this, getString(R.string.backup_created_with_different_name_message, actualBackupName))
+    }
+
+    override fun onBackupRenamed(renamedBackup: Backup, position: Int) {
+        adapter.update(renamedBackup, position)
     }
 
     override fun onBackupApplied() {

--- a/app/src/main/java/org/mozilla/fpm/presentation/mvp/MainContract.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/mvp/MainContract.kt
@@ -24,6 +24,8 @@ interface MainContract {
         fun showLoading()
 
         fun hideLoading()
+
+        fun showBackupCreatedWithDifferentNameMessage(actualBackupName: String)
     }
 
     interface Presenter : BasePresenter<View> {

--- a/app/src/main/java/org/mozilla/fpm/presentation/mvp/MainContract.kt
+++ b/app/src/main/java/org/mozilla/fpm/presentation/mvp/MainContract.kt
@@ -26,6 +26,8 @@ interface MainContract {
         fun hideLoading()
 
         fun showBackupCreatedWithDifferentNameMessage(actualBackupName: String)
+
+        fun onBackupRenamed(renamedBackup: Backup, position: Int)
     }
 
     interface Presenter : BasePresenter<View> {
@@ -37,7 +39,7 @@ interface MainContract {
 
         fun applyBackup(backupName: String)
 
-        fun renameBackup(backup: Backup, newBackupName: String)
+        fun renameBackup(backup: Backup, newBackupName: String, position: Int)
 
         fun deleteBackup(backupName: String)
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -36,4 +36,5 @@
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="choose_backup">Choose backup archive</string>
+    <string name="backup_created_with_different_name_message">Backup was saved under the name \"%1$s\" to not overwrite an already existing backup with the indicated name</string>
 </resources>


### PR DESCRIPTION
The better solution would probably involve an automatic validator for the input texts and dialogs informing about conflicts with an existing backup / offer the chance to overwrite or not / set a different name etc. but this would require significant changes to the current code.

For simplicity I went with just using a decimal suffix in the form `(\d)` to differentiate between conflicting backup names applied automatically by us when a conflict is detected and then show a Toast to the user informing her about this change.