### PR TITLE
Bug 1617128 - Get taskcluster to sign builds with the same keys as Fennec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ out/
 # Gradle files
 .gradle/
 build/
+!taskcluster/ci/build
 
 # Local configuration file (sdk path, etc)
 local.properties
@@ -67,3 +68,8 @@ fastlane/readme.md
 
 # macOS
 .DS_Store
+
+# Python Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+venv/

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,252 @@
+---
+version: 1
+reporting: checks-v1
+policy:
+    pullRequests: public
+tasks:
+    - $let:
+          taskgraph:
+              branch: taskgraph
+              revision: 7a51e874018f13aa236f5dc64ae7bbcaf942fcf3
+          trustDomain: mobile
+      in:
+          $if: 'tasks_for in ["github-pull-request", "github-push", "action", "cron"]'
+          then:
+              $let:
+                  # Github events have this stuff in different places...
+                  ownerEmail:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.pusher.email}'
+                      # Assume Pull Request
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.user.login}@users.noreply.github.com'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${tasks_for}@noreply.mozilla.org'
+                  baseRepoUrl:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.repository.html_url}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.base.repo.html_url}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${repository.url}'
+                  repoUrl:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.repository.html_url}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.head.repo.html_url}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${repository.url}'
+                  project:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.repository.name}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.head.repo.name}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${repository.project}'
+                  head_branch:
+                      $if: 'tasks_for == "github-pull-request"'
+                      then: ${event.pull_request.head.ref}
+                      else:
+                          $if: 'tasks_for == "github-push"'
+                          then: ${event.ref}
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${push.branch}'
+                  head_sha:
+                      $if: 'tasks_for == "github-push"'
+                      then: '${event.after}'
+                      else:
+                          $if: 'tasks_for == "github-pull-request"'
+                          then: '${event.pull_request.head.sha}'
+                          else:
+                              $if: 'tasks_for in ["cron", "action"]'
+                              then: '${push.revision}'
+                  ownTaskId:
+                      $if: '"github" in tasks_for'
+                      then: {$eval: as_slugid("decision_task")}
+                      else:
+                          $if: 'tasks_for == "cron"'
+                          then: '${ownTaskId}'
+              in:
+                  $let:
+                      level:
+                          $if: 'tasks_for in ["github-push", "github-release", "action", "cron"] && repoUrl == "https://github.com/mozilla-mobile/fennec-profile-manager"'
+                          then: '3'
+                          else: '1'
+                  in:
+                      taskId: '${ownTaskId}'
+                      taskGroupId:
+                          $if: 'tasks_for == "action"'
+                          then:
+                              '${action.taskGroupId}'
+                          else:
+                              '${ownTaskId}'  # same as taskId; this is how automation identifies a decision task
+                      schedulerId: '${trustDomain}-level-${level}'
+                      created: {$fromNow: ''}
+                      deadline: {$fromNow: '1 day'}
+                      expires: {$fromNow: '1 year 1 second'}  # 1 second so artifacts expire first, despite rounding errors
+                      metadata:
+                          $merge:
+                              - owner: "${ownerEmail}"
+                                source: '${repoUrl}/raw/${head_sha}/.taskcluster.yml'
+                              - $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                                then:
+                                    name: "Decision Task"
+                                    description: 'The task that creates all of the other tasks in the task graph'
+                                else:
+                                    $if: 'tasks_for == "action"'
+                                    then:
+                                        name: "Action: ${action.title}"
+                                        description: '${action.description}'
+                                    else:
+                                        name: "Decision Task for cron job ${cron.job_name}"
+                                        description: 'Created by a [cron task](https://tools.taskcluster.net/tasks/${cron.task_id})'
+                      provisionerId: "mobile-${level}"
+                      workerType: "decision"
+                      tags:
+                          $if: 'tasks_for in ["github-push", "github-pull-request"]'
+                          then:
+                              kind: decision-task
+                          else:
+                              $if: 'tasks_for == "action"'
+                              then:
+                                  kind: 'action-callback'
+                              else:
+                                  $if: 'tasks_for == "cron"'
+                                  then:
+                                      kind: cron-task
+                      routes:
+                          - checks
+                      scopes:
+                          # `https://` is 8 characters so, ${repoUrl[8:]} is the repository without the protocol.
+                          $if: 'tasks_for == "github-push"'
+                          then:
+                              $let:
+                                  short_head_branch:
+                                      $if: 'head_branch[:10] == "refs/tags/"'
+                                      then: {$eval: 'head_branch[10:]'}
+                                      else:
+                                          $if: 'head_branch[:11] == "refs/heads/"'
+                                          then: {$eval: 'head_branch[11:]'}
+                                          else: ${head_branch}
+                              in:
+                                  - 'assume:repo:${repoUrl[8:]}:branch:${short_head_branch}'
+                          else:
+                              $if: 'tasks_for == "github-pull-request"'
+                              then:
+                                  - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:pull-request'
+                              else:
+                                  $if: 'tasks_for == "action"'
+                                  then:
+                                      # when all actions are hooks, we can calculate this directly rather than using a variable
+                                      - '${action.repo_scope}'
+                                  else:
+                                      - 'assume:repo:${repoUrl[8:]}:cron:${cron.job_name}'
+
+                      requires: all-completed
+                      priority: lowest
+                      retries: 5
+
+                      payload:
+                          env:
+                              # run-task uses these to check out the source; the inputs
+                              # to `mach taskgraph decision` are all on the command line.
+                              $merge:
+                                  - MOBILE_BASE_REPOSITORY: '${baseRepoUrl}'
+                                    MOBILE_HEAD_REPOSITORY: '${repoUrl}'
+                                    MOBILE_HEAD_REF: '${head_branch}'
+                                    MOBILE_HEAD_REV: '${head_sha}'
+                                    MOBILE_REPOSITORY_TYPE: git
+                                    TASKGRAPH_BASE_REPOSITORY: https://hg.mozilla.org/ci/taskgraph
+                                    TASKGRAPH_HEAD_REPOSITORY: https://hg.mozilla.org/ci/${taskgraph.branch}
+                                    TASKGRAPH_HEAD_REV: ${taskgraph.revision}
+                                    TASKGRAPH_REPOSITORY_TYPE: hg
+                                    REPOSITORIES: {$json: {mobile: "fennec-profile-manager", taskgraph: "Taskgraph"}}
+                                    HG_STORE_PATH: /builds/worker/checkouts/hg-store
+                                    ANDROID_SDK_ROOT: /builds/worker/android-sdk
+                                  - $if: 'tasks_for in ["github-pull-request"]'
+                                    then:
+                                        MOBILE_PULL_REQUEST_NUMBER: '${event.pull_request.number}'
+                                  - $if: 'tasks_for == "action"'
+                                    then:
+                                        ACTION_TASK_GROUP_ID: '${action.taskGroupId}'  # taskGroupId of the target task
+                                        ACTION_TASK_ID: {$json: {$eval: 'taskId'}}  # taskId of the target task (JSON-encoded)
+                                        ACTION_INPUT: {$json: {$eval: 'input'}}
+                                        ACTION_CALLBACK: '${action.cb_name}'
+                                  - $if: 'tasks_for == "github-release"'
+                                    then:
+                                        MOBILE_HEAD_TAG: '${event.release.tag_name}'
+                          features:
+                              taskclusterProxy: true
+                              chainOfTrust: true
+                          # Note: This task is built server side without the context or tooling that
+                          # exist in tree so we must hard code the hash
+                          image:
+                              mozillareleases/taskgraph:decision-mobile-6020473b1a928d8df50e234a7ca2e81ade2220a4fb5fbe16b02477dd64a49728@sha256:98d226736b7d03907114bf37938002b90e8a37cbe3a297690e349f1ddddb1d7c
+
+                          maxRunTime: 1800
+
+                          command:
+                              - /usr/local/bin/run-task
+                              - '--mobile-checkout=/builds/worker/checkouts/src'
+                              - '--taskgraph-checkout=/builds/worker/checkouts/taskgraph'
+                              - '--task-cwd=/builds/worker/checkouts/src'
+                              - '--'
+                              - bash
+                              - -cx
+                              - $let:
+                                    extraArgs: {$if: 'tasks_for == "cron"', then: '${cron.quoted_args}', else: ''}
+                                in:
+                                    $if: 'tasks_for == "action"'
+                                    then: >
+                                        cd /builds/worker/checkouts/src &&
+                                        ln -s /builds/worker/artifacts artifacts &&
+                                        taskgraph action-callback
+                                    else: >
+                                        PIP_IGNORE_INSTALLED=0 pip install --user /builds/worker/checkouts/taskgraph &&
+                                        taskcluster/scripts/install-sdk.sh &&
+                                        ln -s /builds/worker/artifacts artifacts &&
+                                        ~/.local/bin/taskgraph decision
+                                        --pushlog-id='0'
+                                        --pushdate='0'
+                                        --project='${project}'
+                                        --message=""
+                                        --owner='${ownerEmail}'
+                                        --level='${level}'
+                                        --base-repository="$MOBILE_BASE_REPOSITORY"
+                                        --head-repository="$MOBILE_HEAD_REPOSITORY"
+                                        --head-ref="$MOBILE_HEAD_REF"
+                                        --head-rev="$MOBILE_HEAD_REV"
+                                        --repository-type="$MOBILE_REPOSITORY_TYPE"
+                                        --tasks-for='${tasks_for}'
+                                        ${extraArgs}
+
+                          artifacts:
+                              'public':
+                                  type: 'directory'
+                                  path: '/builds/worker/artifacts'
+                                  expires: {$fromNow: '1 year'}
+
+                      extra:
+                          $merge:
+                              - $if: 'tasks_for == "action"'
+                                then:
+                                    parent: '${action.taskGroupId}'
+                                    action:
+                                        name: '${action.name}'
+                                        context:
+                                            taskGroupId: '${action.taskGroupId}'
+                                            taskId: {$eval: 'taskId'}
+                                            input: {$eval: 'input'}
+                              - $if: 'tasks_for == "cron"'
+                                then:
+                                    cron: {$json: {$eval: 'cron'}}
+                              - tasks_for: '${tasks_for}'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -93,3 +93,22 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }
+
+// -------------------------------------------------------------------------------------------------
+// Task for printing APK information for the requested variant
+// Usage: "./gradlew printVariants
+// -------------------------------------------------------------------------------------------------
+task printVariants {
+    doLast {
+        def variants = android.applicationVariants.collect {[
+                apks: it.variantData.outputScope.apkDatas.collect {[
+                        abi: 'noarch',  // There is no native code in this project
+                        fileName: it.outputFileName,
+                ]},
+                build_type: it.buildType.name,
+                flavor: it.productFlavors.get(0).name,
+                name: it.name,
+        ]}
+        println 'variants: ' + groovy.json.JsonOutput.toJson(variants)
+    }
+}

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -1,0 +1,42 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - fpm_taskgraph.transforms.build:transforms
+    - taskgraph.transforms.job:transforms
+    - taskgraph.transforms.task:transforms
+
+job-defaults:
+    description: Build Fennec Profile Manager from source code.
+    worker-type: b-android
+    worker:
+        docker-image: {in-tree: base}
+        max-run-time: 7200
+        chain-of-trust: true
+    run:
+        using: gradlew
+        use-caches: false
+        gradle-build-type: release
+    run-on-tasks-for: [github-push, github-pull-request]
+    # Builds generate multiple APKs with different ABIs. For each APK described
+    # by `gradlew printVariants`, an artifact will be generated. `variant` and
+    # the per-apk config from `printVariants` can be used as subsistutions in
+    # `name` and `path`.
+    apk-artifact-template:
+        type: file
+        name: public/target.{abi}.apk
+        path: '/builds/worker/checkouts/src/app/build/outputs/apk/{gradle_flavor}/{gradle_build_type}/{fileName}'
+
+jobs:
+    fennec-nightly:
+        run:
+            gradle-flavor: nightly
+    fennec-beta:
+        run:
+            gradle-flavor: beta
+    fennec-production:
+        run:
+            gradle-flavor: prod

--- a/taskcluster/ci/config.yml
+++ b/taskcluster/ci/config.yml
@@ -1,0 +1,37 @@
+---
+trust-domain: mobile
+treeherder:
+    group-names: {}
+
+task-priority: lowest
+
+taskgraph:
+    register: fpm_taskgraph:register
+    repositories:
+        mobile:
+            name: "fennec-profile-manager"
+    cached-task-prefix: project.mobile.fennec-profile-manager
+
+workers:
+    aliases:
+        b-android:
+            provisioner: 'mobile-{level}'
+            implementation: docker-worker
+            os: linux
+            worker-type: 'b-linux'
+        images:
+            provisioner: 'mobile-{level}'
+            implementation: docker-worker
+            os: linux
+            worker-type: 'images'
+        signing:
+            provisioner: scriptworker-k8s
+            implementation: scriptworker-signing
+            os: scriptworker
+            worker-type:
+                by-level:
+                    "3": mobile-3-signing
+                    default: mobile-t-signing
+
+scriptworker:
+    scope-prefix: project:mobile:fennec-profile-manager:releng

--- a/taskcluster/ci/docker-image/kind.yml
+++ b/taskcluster/ci/docker-image/kind.yml
@@ -1,0 +1,14 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - taskgraph.transforms.docker_image:transforms
+    - taskgraph.transforms.cached_tasks:transforms
+    - taskgraph.transforms.task:transforms
+
+jobs:
+    base: {}

--- a/taskcluster/ci/signing/kind.yml
+++ b/taskcluster/ci/signing/kind.yml
@@ -1,0 +1,53 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+
+loader: fpm_taskgraph.loader.multi_dep:loader
+
+kind-dependencies:
+    - build
+
+transforms:
+    - fpm_taskgraph.transforms.multi_dep:transforms
+    - fpm_taskgraph.transforms.signing:transforms
+    - taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - build
+
+primary-dependency: build
+
+group-by: build-type
+
+job-template:
+    description: Sign Fennec Profile Manager with the original Fennec key
+    index:
+        by-build-type:
+            fennec-(nightly|beta|production):
+                type: signing
+            default: {}
+    signing-format:
+      by-build-type:
+          fennec-nightly:
+              by-level:
+                  # Fennec nightly cannot have the sha256 checksums, when signed with the real key.
+                  # For more details, see
+                  # https://github.com/mozilla-releng/scriptworker-scripts/pull/102#issue-349016967
+                  '3': autograph_apk_fennec_sha1
+                  default: autograph_apk
+          default: autograph_apk
+    worker-type: signing
+    worker:
+        max-run-time: 3600
+        signing-type:
+            by-build-type:
+                fennec-nightly:
+                    by-level:
+                        '3': fennec-nightly-signing
+                        default: dep-signing
+                fennec-(beta|production):
+                    by-level:
+                        '3': fennec-production-signing
+                        default: dep-signing
+                default: dep-signing

--- a/taskcluster/docker/base/Dockerfile
+++ b/taskcluster/docker/base/Dockerfile
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+FROM ubuntu:18.04
+
+MAINTAINER Tom Prince "mozilla@hocat.ca"
+
+# Add worker user
+RUN mkdir /builds && \
+    useradd -d /builds/worker -s /bin/bash -m worker && \
+    chown worker:worker /builds/worker && \
+    mkdir /builds/worker/artifacts && \
+    chown worker:worker /builds/worker/artifacts
+
+WORKDIR /builds/worker/
+
+#----------------------------------------------------------------------------------------------------------------------
+#-- Configuration -----------------------------------------------------------------------------------------------------
+#----------------------------------------------------------------------------------------------------------------------
+
+ENV ANDROID_SDK_VERSION='3859397' \
+    ANDROID_SDK_ROOT='/builds/worker/android-sdk-linux' \
+    GRADLE_OPTS='-Xmx4096m -Dorg.gradle.daemon=false' \
+    LANG='en_US.UTF-8' \
+    TERM='dumb' \
+    SDK_ZIP_LOCATION="$HOME/sdk-tools-linux.zip"
+
+#----------------------------------------------------------------------------------------------------------------------
+#-- System ------------------------------------------------------------------------------------------------------------
+#----------------------------------------------------------------------------------------------------------------------
+
+RUN apt-get update -qq \
+    # We need to install tzdata before all of the other packages. Otherwise it will show an interactive dialog that
+    # we cannot navigate while building the Docker image.
+    && apt-get install -y tzdata \
+    && apt-get install -y openjdk-8-jdk \
+                          wget \
+                          expect \
+                          git \
+                          curl \
+                          python \
+                          python-pip \
+                          python3 \
+                          locales \
+                          unzip \
+			  mercurial \
+    && apt-get clean
+
+RUN pip install --upgrade pip
+RUN pip install taskcluster
+
+RUN locale-gen "$LANG"
+
+RUN curl -o "$SDK_ZIP_LOCATION" "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip" \
+    && unzip -d "$ANDROID_SDK_ROOT" "$SDK_ZIP_LOCATION" \
+    && rm "$SDK_ZIP_LOCATION" \
+    && yes | "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses \
+    && chown -R worker:worker "$ANDROID_SDK_ROOT"
+
+
+# %include-run-task
+
+ENV SHELL=/bin/bash \
+    HOME=/builds/worker \
+    PATH=/builds/worker/.local/bin:$PATH
+
+
+VOLUME /builds/worker/checkouts
+VOLUME /builds/worker/.cache
+
+
+# run-task expects to run as root
+USER root

--- a/taskcluster/fpm_taskgraph/__init__.py
+++ b/taskcluster/fpm_taskgraph/__init__.py
@@ -1,0 +1,20 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from importlib import import_module
+
+
+def register(graph_config):
+    """
+    Import all modules that are siblings of this one, triggering decorators in
+    the process.
+    """
+    _import_modules(["job", "worker_types", "routes"])
+
+
+def _import_modules(modules):
+    for module in modules:
+        import_module(".{}".format(module), package=__name__)

--- a/taskcluster/fpm_taskgraph/gradle.py
+++ b/taskcluster/fpm_taskgraph/gradle.py
@@ -1,0 +1,58 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import json
+import subprocess
+
+from taskgraph.util.memoize import memoize
+
+
+
+def get_variant(build_type, flavor):
+    all_variants = _fetch_all_variants()
+    matching_variants = [
+        variant for variant in all_variants
+        if variant["build_type"] == build_type and variant["flavor"] == flavor
+    ]
+    number_of_matching_variants = len(matching_variants)
+    if number_of_matching_variants == 0:
+        raise ValueError('No variant found for build type "{}" and flavor "{}"'.format(
+            build_type, flavor
+        ))
+    elif number_of_matching_variants > 1:
+        raise ValueError('Too many variants found for build type "{}" and flavor "{}": {}'.format(
+            build_type, flavor, matching_variants
+        ))
+
+    return matching_variants.pop()
+
+
+@memoize
+def _fetch_all_variants():
+    output = _run_gradle_process('printVariants')
+    content = _extract_content_from_command_output(output, prefix='variants: ')
+    return json.loads(content)
+
+
+def _run_gradle_process(gradle_command, **kwargs):
+    gradle_properties = [
+        '-P{property_name}={value}'.format(property_name=property_name, value=value)
+        for property_name, value in kwargs.iteritems()
+    ]
+
+    process = subprocess.Popen(["./gradlew", "--no-daemon", "--quiet", gradle_command] + gradle_properties, stdout=subprocess.PIPE)
+    output, err = process.communicate()
+    exit_code = process.wait()
+
+    if exit_code is not 0:
+        raise RuntimeError("Gradle command returned error: {}".format(exit_code))
+
+    return output
+
+
+def _extract_content_from_command_output(output, prefix):
+    variants_line = [line for line in output.split('\n') if line.startswith(prefix)][0]
+    return variants_line.split(' ', 1)[1]

--- a/taskcluster/fpm_taskgraph/job.py
+++ b/taskcluster/fpm_taskgraph/job.py
@@ -1,0 +1,82 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.job import run_job_using, configure_taskdesc_for_run
+from taskgraph.util import path
+from taskgraph.util.schema import Schema
+from voluptuous import Required, Optional
+from six import text_type
+
+from pipes import quote as shell_quote
+
+gradlew_schema = Schema(
+    {
+        Required("using"): "gradlew",
+        Optional("pre-gradlew"): [[text_type]],
+        Required("gradlew"): [text_type],
+        Optional("post-gradlew"): [[text_type]],
+        # Base work directory used to set up the task.
+        Required("workdir"): text_type,
+        Optional("use-caches"): bool,
+        Optional("secrets"): [
+            {
+                Required("name"): text_type,
+                Required("path"): text_type,
+                Required("key"): text_type,
+                Optional("json"): bool,
+            }
+        ],
+    }
+)
+
+
+@run_job_using("docker-worker", "gradlew", schema=gradlew_schema)
+def configure_gradlew(config, job, taskdesc):
+    run = job["run"]
+    worker = taskdesc["worker"] = job["worker"]
+
+    worker.setdefault("env", {}).update(
+        {"ANDROID_SDK_ROOT": path.join(run["workdir"], "android-sdk-linux")}
+    )
+
+    # defer to the run_task implementation
+    run["command"] = _extract_command(run)
+    secrets = run.pop("secrets", [])
+    scopes = taskdesc.setdefault("scopes", [])
+    new_secret_scopes = ["secrets:get:{}".format(secret["name"]) for secret in secrets]
+    new_secret_scopes = list(set(new_secret_scopes))  # Scopes must not have any duplicates
+    scopes.extend(new_secret_scopes)
+
+    run["cwd"] = "{checkout}"
+    run["using"] = "run-task"
+    configure_taskdesc_for_run(config, job, taskdesc, job["worker"]["implementation"])
+
+
+def _extract_command(run):
+    pre_gradle_commands = run.pop("pre-gradlew", [])
+    pre_gradle_commands += [
+        _generate_secret_command(secret) for secret in run.get("secrets", [])
+    ]
+
+    gradle_command = ["./gradlew"] + run.pop("gradlew")
+    post_gradle_commands = run.pop("post-gradlew", [])
+
+    commands = pre_gradle_commands + [gradle_command] + post_gradle_commands
+    shell_quoted_commands = [" ".join(map(shell_quote, command)) for command in commands]
+    return " && ".join(shell_quoted_commands)
+
+
+def _generate_secret_command(secret):
+    secret_command = [
+        "taskcluster/scripts/get-secret.py",
+        "-s", secret["name"],
+        "-k", secret["key"],
+        "-f", secret["path"],
+    ]
+    if secret.get("json"):
+        secret_command.append("--json")
+
+    return secret_command

--- a/taskcluster/fpm_taskgraph/loader/__init__.py
+++ b/taskcluster/fpm_taskgraph/loader/__init__.py
@@ -1,0 +1,51 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import copy
+
+
+# Define a collection of group_by functions
+GROUP_BY_MAP = {}
+
+
+def group_by(name):
+    def wrapper(func):
+        GROUP_BY_MAP[name] = func
+        return func
+    return wrapper
+
+
+
+def group_tasks(config, tasks):
+    group_by_fn = GROUP_BY_MAP[config['group-by']]
+
+    groups = group_by_fn(config, tasks)
+
+    for combinations in groups.itervalues():
+        dependencies = [copy.deepcopy(t) for t in combinations]
+        yield dependencies
+
+
+@group_by('build-type')
+def build_type_grouping(config, tasks):
+    groups = {}
+    kind_dependencies = config.get('kind-dependencies')
+    only_build_type = config.get('only-for-build-types')
+
+    for task in tasks:
+        if task.kind not in kind_dependencies:
+            continue
+
+        if only_build_type:
+            build_type = task.attributes.get('build-type')
+            if build_type not in only_build_type:
+                continue
+
+        build_type = task.attributes.get('build-type')
+
+        groups.setdefault(build_type, []).append(task)
+
+    return groups

--- a/taskcluster/fpm_taskgraph/loader/multi_dep.py
+++ b/taskcluster/fpm_taskgraph/loader/multi_dep.py
@@ -1,0 +1,87 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import copy
+
+from voluptuous import Required
+
+from taskgraph.task import Task
+from taskgraph.util.attributes import sorted_unique_list
+from taskgraph.util.schema import Schema
+
+from . import group_tasks
+
+
+schema = Schema({
+    Required('primary-dependency', 'primary dependency task'): Task,
+    Required(
+        'dependent-tasks',
+        'dictionary of dependent tasks, keyed by kind',
+    ): {basestring: Task},
+})
+
+
+
+def loader(kind, path, config, params, loaded_tasks):
+    """
+    Load tasks based on the jobs dependant kinds, designed for use as
+    multiple-dependent needs.
+    Required ``group-by-fn`` is used to define how we coalesce the
+    multiple deps together to pass to transforms, e.g. all kinds specified get
+    collapsed by platform with `platform`
+    Optional ``primary-dependency`` (ordered list or string) is used to determine
+    which upstream kind to inherit attrs from. See ``get_primary_dep``.
+    The `only-for-build-type` kind configuration, if specified, will limit
+    the build types for which a job will be created.
+    Optional ``job-template`` kind configuration value, if specified, will be used to
+    pass configuration down to the specified transforms used.
+    """
+    job_template = config.get('job-template')
+
+    for dep_tasks in group_tasks(config, loaded_tasks):
+        kinds = [dep.kind for dep in dep_tasks]
+        kinds_occurrences = {kind: kinds.count(kind) for kind in kinds}
+
+        dep_tasks_per_unique_key = {
+            dep.kind if kinds_occurrences[dep.kind] == 1 else dep.label: dep
+            for dep in dep_tasks
+        }
+
+        job = {'dependent-tasks': dep_tasks_per_unique_key}
+        job['primary-dependency'] = get_primary_dep(config, dep_tasks_per_unique_key)
+        if job_template:
+            job.update(copy.deepcopy(job_template))
+
+        yield job
+
+
+def get_primary_dep(config, dep_tasks):
+    """Find the dependent task to inherit attributes from.
+    If ``primary-dependency`` is defined in ``kind.yml`` and is a string,
+    then find the first dep with that task kind and return it. If it is
+    defined and is a list, the first kind in that list with a matching dep
+    is the primary dependency. If it's undefined, return the first dep.
+    """
+    primary_dependencies = config.get('primary-dependency')
+    if isinstance(primary_dependencies, basestring):
+        primary_dependencies = [primary_dependencies]
+    if not primary_dependencies:
+        assert len(dep_tasks) == 1, "Must define a primary-dependency!"
+        return dep_tasks.values()[0]
+    primary_dep = None
+    for primary_kind in primary_dependencies:
+        for dep_kind in dep_tasks:
+            if dep_kind == primary_kind:
+                assert primary_dep is None, \
+                    "Too many primary dependent tasks in dep_tasks: {}!".format(
+                        [t.label for t in dep_tasks]
+                    )
+                primary_dep = dep_tasks[dep_kind]
+    if primary_dep is None:
+        raise Exception("Can't find dependency of {}: {}".format(
+            config['primary-dependency'], config
+        ))
+    return primary_dep

--- a/taskcluster/fpm_taskgraph/routes.py
+++ b/taskcluster/fpm_taskgraph/routes.py
@@ -1,0 +1,34 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import time
+
+from taskgraph.transforms.task import index_builder
+
+SIGNING_ROUTE_TEMPLATES = [
+    "index.project.{trust-domain}.{project}.v3.{variant}.{build_date}.revision.{head_rev}",
+    "index.project.{trust-domain}.{project}.v3.{variant}.{build_date}.latest",
+    "index.project.{trust-domain}.{project}.v3.{variant}.latest",
+]
+
+
+@index_builder("signing")
+def add_signing_indexes(config, task):
+    routes = task.setdefault("routes", [])
+
+    if config.params["level"] != "3":
+        return task
+
+    subs = config.params.copy()
+    subs["build_date"] = time.strftime(
+        "%Y.%m.%d", time.gmtime(config.params["build_date"])
+    )
+    subs["trust-domain"] = config.graph_config["trust-domain"]
+    subs["variant"] = task["attributes"]["build-type"]
+
+    for tpl in SIGNING_ROUTE_TEMPLATES:
+        routes.append(tpl.format(**subs))
+    return task

--- a/taskcluster/fpm_taskgraph/transforms/build.py
+++ b/taskcluster/fpm_taskgraph/transforms/build.py
@@ -1,0 +1,72 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the jobs defined in the build
+kind.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+import datetime
+
+from taskgraph.transforms.base import TransformSequence
+from fpm_taskgraph.gradle import get_variant
+from fpm_taskgraph.util import upper_case_first_letter
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_variant_config(config, tasks):
+    for task in tasks:
+        attributes = task.setdefault("attributes", {})
+        if not attributes.get("build-type"):
+            attributes["build-type"] = task["name"]
+
+        yield task
+
+
+@transforms.add
+def build_gradle_command(config, tasks):
+    for task in tasks:
+        gradle_build_type = task["run"]["gradle-build-type"]
+        gradle_flavor = task["run"]["gradle-flavor"]
+        variant_config = get_variant(gradle_build_type, gradle_flavor)
+
+        task["run"]["gradlew"] = [
+            "clean",
+            "assemble{}".format(upper_case_first_letter(variant_config["name"]))
+        ]
+
+        yield task
+
+
+@transforms.add
+def add_artifacts(config, tasks):
+    for task in tasks:
+        gradle_build_type = task["run"].pop("gradle-build-type")
+        gradle_flavor = task["run"].pop("gradle-flavor")
+        variant_config = get_variant(gradle_build_type, gradle_flavor)
+        artifacts = task.setdefault("worker", {}).setdefault("artifacts", [])
+        task["attributes"]["apks"] = apks = {}
+
+        if "apk-artifact-template" in task:
+            artifact_template = task.pop("apk-artifact-template")
+            for apk in variant_config["apks"]:
+                apk_name = artifact_template["name"].format(
+                    gradle_flavor=gradle_flavor, **apk
+                )
+                artifacts.append({
+                    "type": artifact_template["type"],
+                    "name": apk_name,
+                    "path": artifact_template["path"].format(
+                        gradle_flavor=gradle_flavor,
+                        gradle_build_type=gradle_build_type,
+                        **apk
+                    ),
+                })
+                apks[apk["abi"]] = apk_name
+
+        yield task

--- a/taskcluster/fpm_taskgraph/transforms/multi_dep.py
+++ b/taskcluster/fpm_taskgraph/transforms/multi_dep.py
@@ -1,0 +1,74 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the single_dep jobs.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+from taskgraph.util.treeherder import inherit_treeherder_from_dep, join_symbol
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def build_name_and_attributes(config, tasks):
+    for task in tasks:
+        task["dependencies"] = {
+            dep_key: dep.label
+            for dep_key, dep in _get_all_deps(task).iteritems()
+        }
+        primary_dep = task.pop("primary-dependency")
+        copy_of_attributes = primary_dep.attributes.copy()
+        task.setdefault("attributes", copy_of_attributes)
+        # run_on_tasks_for is set as an attribute later in the pipeline
+        task.setdefault("run-on-tasks-for", copy_of_attributes['run_on_tasks_for'])
+        task["name"] = _get_dependent_job_name_without_its_kind(primary_dep)
+
+        yield task
+
+
+def _get_dependent_job_name_without_its_kind(dependent_job):
+    return dependent_job.label[len(dependent_job.kind) + 1:]
+
+
+def _get_all_deps(task):
+    if task.get("dependent-tasks"):
+        return task["dependent-tasks"]
+
+    return {task["primary-dependency"].kind: task["primary-dependency"]}
+
+
+@transforms.add
+def build_upstream_artifacts(config, tasks):
+    for task in tasks:
+        worker_definition = {
+            "upstream-artifacts": [],
+        }
+
+        for dep in _get_all_deps(task).values():
+            paths = sorted(dep.attributes.get("apks", {}).values())
+            if paths:
+                worker_definition["upstream-artifacts"].append({
+                    "taskId": {"task-reference": "<{}>".format(dep.kind)},
+                    "taskType": dep.kind,
+                    "paths": paths,
+                })
+
+        task["worker"].update(worker_definition)
+        yield task
+
+
+@transforms.add
+def remove_dependent_tasks(config, tasks):
+    for task in tasks:
+        try:
+            del task["dependent-tasks"]
+        except KeyError:
+            pass
+
+        yield task

--- a/taskcluster/fpm_taskgraph/transforms/signing.py
+++ b/taskcluster/fpm_taskgraph/transforms/signing.py
@@ -1,0 +1,47 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""
+Apply some defaults and minor modifications to the jobs defined in the build
+kind.
+"""
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from taskgraph.transforms.base import TransformSequence
+from taskgraph.util.schema import resolve_keyed_by
+
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def resolve_keys(config, tasks):
+    for task in tasks:
+        for key in ("index", "worker.signing-type", "signing-format"):
+            resolve_keyed_by(
+                task,
+                key,
+                item_name=task["name"],
+                **{
+                    'build-type': task["attributes"]["build-type"],
+                    'level': config.params["level"],
+                }
+            )
+        yield task
+
+
+@transforms.add
+def set_signing_attributes(config, tasks):
+    for task in tasks:
+        task["attributes"]["signed"] = True
+        yield task
+
+
+@transforms.add
+def set_signing_format(config, tasks):
+    for task in tasks:
+        signing_format = task.pop("signing-format")
+        for upstream_artifact in task["worker"]["upstream-artifacts"]:
+            upstream_artifact["formats"] = [signing_format]
+        yield task

--- a/taskcluster/fpm_taskgraph/util.py
+++ b/taskcluster/fpm_taskgraph/util.py
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+
+def upper_case_first_letter(string):
+    return string[0].upper() + string[1:]

--- a/taskcluster/fpm_taskgraph/worker_types.py
+++ b/taskcluster/fpm_taskgraph/worker_types.py
@@ -1,0 +1,59 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from __future__ import absolute_import, print_function, unicode_literals
+
+from six import text_type
+
+from voluptuous import Required
+
+from taskgraph.util.schema import taskref_or_string
+from taskgraph.transforms.task import payload_builder
+
+
+@payload_builder(
+    "scriptworker-signing",
+    schema={
+        # the maximum time to run, in seconds
+        Required("max-run-time"): int,
+        Required("signing-type"): text_type,
+        # list of artifact URLs for the artifacts that should be signed
+        Required("upstream-artifacts"): [
+            {
+                # taskId of the task with the artifact
+                Required("taskId"): taskref_or_string,
+                # type of signing task (for CoT)
+                Required("taskType"): text_type,
+                # Paths to the artifacts to sign
+                Required("paths"): [text_type],
+                # Signing formats to use on each of the paths
+                Required("formats"): [text_type],
+            }
+        ],
+    },
+)
+def build_scriptworker_signing_payload(config, task, task_def):
+    worker = task["worker"]
+
+    task_def["tags"]["worker-implementation"] = "scriptworker"
+
+    task_def["payload"] = {
+        "maxRunTime": worker["max-run-time"],
+        "upstreamArtifacts": worker["upstream-artifacts"],
+    }
+
+    formats = set()
+    for artifacts in worker["upstream-artifacts"]:
+        formats.update(artifacts["formats"])
+
+    scope_prefix = config.graph_config["scriptworker"]["scope-prefix"]
+    task_def["scopes"].append(
+        "{}:signing:cert:{}".format(scope_prefix, worker["signing-type"])
+    )
+    task_def["scopes"].extend(
+        [
+            "{}:signing:format:{}".format(scope_prefix, format)
+            for format in sorted(formats)
+        ]
+    )

--- a/taskcluster/scripts/install-sdk.sh
+++ b/taskcluster/scripts/install-sdk.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set +x
+
+ANDROID_SDK_VERSION=3859397
+
+curl -o "$HOME/sdk-tools-linux.zip" "https://dl.google.com/android/repository/sdk-tools-linux-${ANDROID_SDK_VERSION}.zip"
+unzip -d "$ANDROID_SDK_ROOT" "$HOME/sdk-tools-linux.zip"
+yes | "${ANDROID_SDK_ROOT}/tools/bin/sdkmanager" --licenses


### PR DESCRIPTION
Context at https://bugzilla.mozilla.org/show_bug.cgi?id=1617128

Tested in staging at: https://firefox-ci-tc.services.mozilla.com/tasks/groups/ArJHfsQUTEK6EoKgk5099Q

Depends on: https://phabricator.services.mozilla.com/D63852 and on https://github.com/mozilla-releng/scriptworker-scripts/pull/151

This patch add taskgraph to project. Taskgraph outputs 2 graphs: on `github-push` and on `github-pull-request`. Both graphs build and sign the artifacts. Pushes on the main repo will sign artifacts with the **real** keys. PRs will just get dep ones.

Most of the files have been copied from either Reference-Browser or Fenix. I'll tell what changed.